### PR TITLE
Treat ambiguous responses as "no" in filename decoding confirmation

### DIFF
--- a/crates/zifu/src/bin/zifu.rs
+++ b/crates/zifu/src/bin/zifu.rs
@@ -115,9 +115,13 @@ fn process_answer_default_no(ans: &str) -> bool {
     };
 }
 
-/// Returns `Ok(false)` if a line starting with `'n'` (or `'N'`) is input from stdin, otherwise `Ok(true)`.
+/// Reads a line from stdin and interprets it as a yes/no answer.
 ///
-/// Returns `Err(std::io::Error)` if I/O fails.
+/// Returns `Ok(true)` if the line starts with `'y'` or `'Y'`.
+/// Returns `Ok(false)` if the line is empty, starts with any other character,
+/// or cannot be interpreted as a yes answer.
+///
+/// Returns `Err(std::io::Error)` if reading from stdin fails.
 fn ask_default_no() -> Result<bool, std::io::Error> {
     let ask_result = (|| {
         let mut ret = String::new();

--- a/crates/zifu/src/bin/zifu.rs
+++ b/crates/zifu/src/bin/zifu.rs
@@ -110,8 +110,8 @@ fn list_names_in_archive(fie_name_entries: &[FileNameEntry], legacy_decoder: &dy
 
 fn process_answer_default_yes(ans: &str) -> bool {
     return match ans.chars().next() {
-        Some('n') | Some('N') => false,
-        None | Some(_) => true,
+        Some('y') | Some('Y') => true,
+        None | Some(_) => false,
     };
 }
 

--- a/crates/zifu/src/bin/zifu.rs
+++ b/crates/zifu/src/bin/zifu.rs
@@ -108,7 +108,7 @@ fn list_names_in_archive(fie_name_entries: &[FileNameEntry], legacy_decoder: &dy
     }
 }
 
-fn process_answer_default_yes(ans: &str) -> bool {
+fn process_answer_default_no(ans: &str) -> bool {
     return match ans.chars().next() {
         Some('y') | Some('Y') => true,
         None | Some(_) => false,
@@ -118,7 +118,7 @@ fn process_answer_default_yes(ans: &str) -> bool {
 /// Returns `Ok(false)` if a line starting with `'n'` (or `'N'`) is input from stdin, otherwise `Ok(true)`.
 ///
 /// Returns `Err(std::io::Error)` if I/O fails.
-fn ask_default_yes() -> Result<bool, std::io::Error> {
+fn ask_default_no() -> Result<bool, std::io::Error> {
     let ask_result = (|| {
         let mut ret = String::new();
         match std::io::stdin().read_line(&mut ret) {
@@ -126,7 +126,7 @@ fn ask_default_yes() -> Result<bool, std::io::Error> {
             Err(e) => return Err(e),
         }
     })()?;
-    return Ok(process_answer_default_yes(&ask_result));
+    return Ok(process_answer_default_no(&ask_result));
 }
 
 #[derive(Parser, Debug)]
@@ -260,7 +260,7 @@ fn main() -> anyhow::Result<()> {
 
         if behavior_flags.ask_user {
             eprint!("Are these file names correct? [Y/n]: ");
-            if !(ask_default_yes()?) {
+            if !(ask_default_no()?) {
                 std::process::exit(1);
             }
         }

--- a/crates/zifu/src/bin/zifu.rs
+++ b/crates/zifu/src/bin/zifu.rs
@@ -1,4 +1,5 @@
 use ansi_term::ANSIGenericString;
+use ansi_term::Colour::Red;
 use anyhow::anyhow;
 use clap::Parser;
 use filename_decoder::IDecoder;
@@ -263,7 +264,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         if behavior_flags.ask_user {
-            eprint!("Are these file names correct? [Y/n]: ");
+            eprint!("Are these file names correct? [y/{}]: ", Red.paint("N"));
             if !(ask_default_no()?) {
                 std::process::exit(1);
             }


### PR DESCRIPTION
This PR corrects the logic in the process_answer_default_yes function. This fix ensures that 'y' returns true and 'n' returns false, preventing unintended actions.

This issue has already caused incorrect file operations. Please merge this PR as soon as possible to prevent further issues.

------

日本語

このPRは、process_answer_default_yes 関数のロジックを修正します。今回の修正により、'y' が true を、'n' が false を返すようになり、意図しない操作を防ぎます。

本件はすでにファイルの誤操作を引き起こしております。これ以上の問題を防ぐため、このPRをできるだけ早くマージしてください。